### PR TITLE
Register API viewsets in router for iOS app

### DIFF
--- a/config/api_router.py
+++ b/config/api_router.py
@@ -1,6 +1,12 @@
 from django.conf import settings
 from rest_framework.routers import DefaultRouter, SimpleRouter
 
+from intentions_page.api.views import (
+    IntentionViewSet,
+    IntentionsDraftViewSet,
+    NoteViewSet,
+    RecurringIntentionViewSet,
+)
 from intentions_page.users.api.views import UserViewSet
 
 if settings.DEBUG:
@@ -9,6 +15,10 @@ else:
     router = SimpleRouter()
 
 router.register("users", UserViewSet)
+router.register("intentions", IntentionViewSet, basename="intention")
+router.register("notes", NoteViewSet, basename="note")
+router.register("drafts", IntentionsDraftViewSet, basename="draft")
+router.register("recurring", RecurringIntentionViewSet, basename="recurring")
 
 
 app_name = "api"


### PR DESCRIPTION
## Summary
Registers the intention-related viewsets in the DRF router to enable iOS app API endpoints.

## Changes
- Register IntentionViewSet at `/api/intentions/`
- Register NoteViewSet at `/api/notes/`
- Register IntentionsDraftViewSet at `/api/drafts/`
- Register RecurringIntentionViewSet at `/api/recurring/`

## Context
These viewsets were created in the previous commit (e3857ac) but weren't registered in the router, causing 404 errors when the iOS app tried to fetch intentions after successful OAuth authentication.

## Testing
After merging and deploying:
- iOS app should successfully fetch intentions: `GET /api/intentions/?date=2026-02-09`
- All other intention CRUD operations should work

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>